### PR TITLE
HackText: only use imported libraries and process text node even if has textStyleId token (because may now be obsolete)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Design Lint",
+  "name": "OTKit Design Lint",
   "id": "801195587640428208",
   "api": "1.0.0",
   "main": "dist/code.js",

--- a/src/plugin/controller.ts
+++ b/src/plugin/controller.ts
@@ -1612,6 +1612,9 @@ figma.ui.onmessage = msg => {
     let errors = [];
 
     checkType(node, errors, libraries, localStylesLibrary, usedRemoteStyles);
+
+    console.log("lintTextRules after checkType -> errors", errors);
+
     newCheckFills(
       node,
       errors,

--- a/src/plugin/lintingFunctions.ts
+++ b/src/plugin/lintingFunctions.ts
@@ -1086,7 +1086,7 @@ export function checkType(
           "text",
           node.textStyleId === ""
             ? "Missing text style"
-            : "Depreated text style",
+            : "Deprecated text style",
           currentStyle,
           matchingStyles
         )

--- a/src/plugin/lintingFunctions.ts
+++ b/src/plugin/lintingFunctions.ts
@@ -931,7 +931,14 @@ export function checkType(
   localStylesLibrary,
   importedStyles
 ) {
-  if (node.textStyleId === "" && node.visible === true) {
+  console.log("checkType node: ", node);
+  console.log("checkType node.textStyleId: ", node.textStyleId);
+  console.log("checkType node.visible: ", node.visible);
+
+  // hack: change to original code: even if a node has a textStyleId it may be obsolete
+  // so go ahead and process it
+  // if (node.textStyleId === "" && node.visible === true) {
+  if (node.visible === true) {
     let textObject = {
       font: "",
       fontStyle: "",
@@ -960,6 +967,8 @@ export function checkType(
       );
     }
 
+    console.log("checkType past fontStyle === symbol check: ");
+
     textObject.font = node.fontName.family;
     textObject.fontStyle = node.fontName.style;
     textObject.fontSize = node.fontSize;
@@ -982,8 +991,11 @@ export function checkType(
     let suggestedStyles = [];
 
     const checkSuggestions = library => {
+      console.log("checkSuggestions library:", library);
+
       for (const textStyle of library.text) {
         const style = textStyle.style;
+        console.log("checkSuggestions style:", style);
 
         let lineHeightCheck: string;
 
@@ -1032,14 +1044,15 @@ export function checkType(
       }
     };
 
+    // hack: ignore imported and local styles and just check libraries
     // See if we have matches with remote styles
-    if (importedStyles && importedStyles.text) {
-      checkSuggestions(importedStyles);
-    }
+    // if (importedStyles && importedStyles.text) {
+    //   checkSuggestions(importedStyles);
+    // }
 
-    if (localStylesLibrary && localStylesLibrary.text) {
-      checkSuggestions(localStylesLibrary);
-    }
+    // if (localStylesLibrary && localStylesLibrary.text) {
+    //   checkSuggestions(localStylesLibrary);
+    // }
 
     if (matchingStyles.length === 0 && libraries && libraries.length > 0) {
       for (const library of libraries) {
@@ -1065,12 +1078,15 @@ export function checkType(
     let currentStyle = `${textObject.font} ${textObject.fontStyle} · ${textObject.fontSize}/${lineHeightFormatted}`;
 
     // Create error object with fixes if matching styles are found
+    // hack: if node has a textStyleId token then show custom deprected message for that
     if (matchingStyles.length > 0) {
       return errors.push(
         createErrorObject(
           node,
           "text",
-          "Missing text style",
+          node.textStyleId === ""
+            ? "Missing text style"
+            : "Depreated text style",
           currentStyle,
           matchingStyles
         )


### PR DESCRIPTION
Changes
- only use imported libraries (ignore local styles)
- process text node even if has textStyleId token (because that may now be obsolete)
- show custom message in case node has a token (node.textStyleId !== "")
- change plugin name in manifest per requirements